### PR TITLE
Allows string type in prediction results

### DIFF
--- a/fastapi_mlflow/predictors.py
+++ b/fastapi_mlflow/predictors.py
@@ -80,7 +80,7 @@ def build_predictor(model: PyFuncModel) -> Callable[[BaseModel], Any]:
             # Replace NaN with None
             response_data = []
             for row in results:
-                value = row if not np.isnan(row) else None
+                value = row if type(row) == "str" or not np.isnan(row) else None
                 response_data.append({"prediction": value})
 
         return Response(data=response_data)


### PR DESCRIPTION
Thank you for such a great library!

I noticed that if a model returns an array of strings ("str") we'd be getting the following error.
```
Traceback (most recent call last):
  File "/opt/conda/envs/mlflow-env/lib/python3.9/site-packages/fastapi_mlflow/predictors.py", line 74, in predictor
    results.fillna(np.nan)
AttributeError: 'numpy.ndarray' object has no attribute 'fillna'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
...........................
  File "/opt/conda/envs/mlflow-env/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "/opt/conda/envs/mlflow-env/lib/python3.9/site-packages/fastapi_mlflow/predictors.py", line 83, in predictor
    value = row if not np.isnan(row) else None
TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

I suggest this change to allow returning strings from a predictor, however, there might be a more clever one :) 