### PR TITLE
Catch and expose errors from ML model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [ main ]
 
 jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+      - name: Run flake8
+        run: |
+          poetry run flake8 fastapi_mlflow tests
+      - name: Run mypy
+        run: |
+          poetry run mypy fastapi_mlflow tests
+
   build:
 
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Catch errors raised by ML model's predict method, format them as JSON, and return as the body of the 500 status response.
 
 ## [0.3.2] - 2022-01-13
 ### Fixed
@@ -13,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1] - 2022-11-24
 ### Fixed
 - Assume that prediction output field(s) may be nullable. It's not uncommon to want ML models to return null or nan values at inference time (e.g. extrapolation outside of training data range).
-- Coerce nan values in output to null in JSON
+- Coerce nan values in output to null in JSON.
 
 ## [0.3.0] - 2022-10-07
 ### Added

--- a/fastapi_mlflow/_mlflow_types.py
+++ b/fastapi_mlflow/_mlflow_types.py
@@ -7,8 +7,6 @@ Copyright (C) 2022, Auto Trader UK
 from datetime import date, datetime
 from typing import Dict, Optional, Union
 
-from mlflow.types import Schema  # type: ignore
-
 MLFLOW_SIGNATURE_TO_PYTHON_TYPE_MAP = {
     "boolean": bool,
     "integer": int,

--- a/fastapi_mlflow/applications.py
+++ b/fastapi_mlflow/applications.py
@@ -6,10 +6,14 @@ Copyright (C) 2022, Auto Trader UK
 """
 from inspect import signature
 
-from fastapi import FastAPI
-from mlflow.pyfunc import PyFuncModel  # type: ignore
+from fastapi import (
+    FastAPI,
+    Request,
+)
+from fastapi.responses import JSONResponse
 
-from fastapi_mlflow.predictors import build_predictor
+from mlflow.pyfunc import PyFuncModel  # type: ignore
+from fastapi_mlflow.predictors import build_predictor, PyFuncModelPredictError
 
 
 def build_app(pyfunc_model: PyFuncModel) -> FastAPI:
@@ -23,4 +27,12 @@ def build_app(pyfunc_model: PyFuncModel) -> FastAPI:
         response_model=response_model,
         methods=["POST"],
     )
+
+    @app.exception_handler(Exception)
+    def handle_exception(_: Request, exc: PyFuncModelPredictError):
+        return JSONResponse(
+            status_code=500,
+            content=exc.to_dict(),
+        )
+
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ import numpy.typing as npt
 import pandas as pd
 import pytest
 from mlflow.models import infer_signature  # type: ignore
-from mlflow.pyfunc import PyFuncModel, PythonModel, PythonModelContext
+from mlflow.pyfunc import PyFuncModel, PythonModel, PythonModelContext  # type: ignore
 from mlflow.pyfunc import load_model as pyfunc_load_model  # type: ignore
 from mlflow.pyfunc import save_model as pyfunc_save_model
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -60,7 +60,7 @@ def test_build_app_returns_good_predictions(
     df_str = model_input.to_json(orient="records")
     request_data = f'{{"data": {df_str}}}'
 
-    response = client.post("/predictions", json=request_data)
+    response = client.post("/predictions", content=request_data)
 
     assert response.status_code == 200
     results = response.json()["data"]
@@ -80,7 +80,7 @@ def test_built_application_handles_model_exceptions(
     df_str = model_input.to_json(orient="records")
     request_data = f'{{"data": {df_str}}}'
 
-    response = client.post("/predictions", json=request_data)
+    response = client.post("/predictions", content=request_data)
 
     assert response.status_code == 500
     assert {

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -60,7 +60,9 @@ def test_build_app_returns_good_predictions(
     client = TestClient(app)
     df_str = model_input.to_json(orient="records")
     request_data = f'{{"data": {df_str}}}'
-    response = client.post("/predictions", data=request_data)
+
+    response = client.post("/predictions", json=request_data)
+
     assert response.status_code == 200
     results = response.json()["data"]
     try:

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -66,7 +66,7 @@ class TestNaNNDArrayPyFuncModel:
 
     def test_pyfunc_model_nan_ndarray_predict(
         self,
-            pyfunc_model_nan_ndarray,
+        pyfunc_model_nan_ndarray,
         model_input: pd.DataFrame,
     ):
         """PyFunc model with ndarray return type should predict correct values."""

--- a/tests/test_mlflow_types.py
+++ b/tests/test_mlflow_types.py
@@ -8,8 +8,7 @@ Created 21. Nov 2022
 from typing import Optional
 
 import pytest
-from mlflow.pyfunc import PyFuncModel
-from mlflow.types.schema import Schema, ColSpec, DataType
+from mlflow.types.schema import Schema, ColSpec, DataType  # type: ignore
 from fastapi_mlflow._mlflow_types import build_model_fields
 
 


### PR DESCRIPTION
Catch errors raised by ML model's predict method, format them as JSON,
and return as the body of the `500` status response.

This empowers clients to interpret errors raised internally.